### PR TITLE
Add environment support to healthcheck

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -18,11 +18,10 @@ func Init() {
 		log.Fatal("failed to connect database:", err)
 	}
 
-	err = DB.AutoMigrate(&models.URL{}, &models.HealthCheckRecord{})
+	err = DB.AutoMigrate(&models.Environment{}, &models.URL{}, &models.HealthCheckRecord{})
 	if err != nil {
 		log.Fatal("failed to migrate models:", err)
 	}
 
 	SeedURLsFromFile("db/urls.json")
 }
-

--- a/db/seed.go
+++ b/db/seed.go
@@ -16,19 +16,28 @@ func SeedURLsFromFile(path string) {
 	}
 	defer file.Close()
 
-	var urls []string
-	err = json.NewDecoder(file).Decode(&urls)
+	var envMap map[string][]string
+	err = json.NewDecoder(file).Decode(&envMap)
 	if err != nil {
 		log.Fatalf("Failed to decode URL seed file: %v", err)
 	}
 
-	for _, u := range urls {
-		var url models.URL
-		result := DB.FirstOrCreate(&url, models.URL{Target: u})
+	for envName, urls := range envMap {
+		var env models.Environment
+		result := DB.FirstOrCreate(&env, models.Environment{Name: envName})
 		if result.Error != nil {
-			log.Printf("Failed to insert URL %s: %v", u, result.Error)
-		} else if result.RowsAffected > 0 {
-			log.Printf("Seeded URL: %s", u)
+			log.Printf("Failed to insert environment %s: %v", envName, result.Error)
+			continue
+		}
+
+		for _, u := range urls {
+			var url models.URL
+			result := DB.FirstOrCreate(&url, models.URL{Target: u, EnvironmentID: env.ID})
+			if result.Error != nil {
+				log.Printf("Failed to insert URL %s: %v", u, result.Error)
+			} else if result.RowsAffected > 0 {
+				log.Printf("Seeded URL: %s under %s", u, envName)
+			}
 		}
 	}
 }

--- a/db/urls.json
+++ b/db/urls.json
@@ -1,5 +1,9 @@
-[
-  "https://httpbin.org/status/200",
-  "https://httpstat.us/200"
-]
-
+{
+  "prod": [
+    "https://httpbin.org/status/200",
+    "https://httpstat.us/200"
+  ],
+  "nonprod": [
+    "https://httpbin.org/status/204"
+  ]
+}

--- a/models/environment.go
+++ b/models/environment.go
@@ -1,0 +1,7 @@
+package models
+
+// Environment represents a deployment environment like prod or nonprod.
+type Environment struct {
+	ID   uint   `gorm:"primaryKey"`
+	Name string `gorm:"uniqueIndex"`
+}

--- a/models/url.go
+++ b/models/url.go
@@ -1,7 +1,8 @@
 package models
 
 type URL struct {
-	ID     uint   `gorm:"primaryKey"`
-	Target string `gorm:"uniqueIndex"`
+	ID            uint        `gorm:"primaryKey"`
+	EnvironmentID uint        `gorm:"uniqueIndex:idx_env_target"`
+	Environment   Environment `gorm:"foreignKey:EnvironmentID"`
+	Target        string      `gorm:"uniqueIndex:idx_env_target"`
 }
-

--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -13,6 +13,7 @@
     <table class="records-table">
       <thead>
         <tr>
+          <th>Environment</th>
           <th>URL</th>
           <th>Status</th>
           <th>Timestamp</th>
@@ -20,11 +21,12 @@
       </thead>
       <tbody>
         <tr *ngFor="let r of records">
+          <td>{{ r.url?.environment?.name }}</td>
           <td>{{ r.url?.target }}</td>
           <td [ngClass]="r.status_code < 400 ? 'status-up' : 'status-down'">
             {{ r.status_code }}
           </td>
-          <td>{{ r.timestamp | date: 'short' }}</td>
+          <td>{{ r.timestamp | date: "short" }}</td>
         </tr>
       </tbody>
     </table>

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -1,10 +1,16 @@
-import { Component, OnInit } from '@angular/core';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { CommonModule } from '@angular/common';
+import { Component, OnInit } from "@angular/core";
+import { HttpClient, HttpClientModule } from "@angular/common/http";
+import { CommonModule } from "@angular/common";
+
+interface EnvironmentItem {
+  id: number;
+  name: string;
+}
 
 interface URLItem {
   id: number;
   target: string;
+  environment?: EnvironmentItem;
 }
 
 interface RecordItem {
@@ -16,11 +22,11 @@ interface RecordItem {
 }
 
 @Component({
-  selector: 'app-root',
+  selector: "app-root",
   standalone: true,
   imports: [CommonModule, HttpClientModule],
-  templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css']
+  templateUrl: "./app.component.html",
+  styleUrls: ["./app.component.css"],
 })
 export class AppComponent implements OnInit {
   urls: URLItem[] = [];
@@ -29,7 +35,9 @@ export class AppComponent implements OnInit {
   constructor(private http: HttpClient) {}
 
   ngOnInit() {
-    this.http.get<URLItem[]>('/urls').subscribe(d => this.urls = d);
-    this.http.get<RecordItem[]>('/records').subscribe(d => this.records = d);
+    this.http.get<URLItem[]>("/urls").subscribe((d) => (this.urls = d));
+    this.http
+      .get<RecordItem[]>("/records")
+      .subscribe((d) => (this.records = d));
   }
 }


### PR DESCRIPTION
## Summary
- track deployment environments in the database
- preload `Environment` for URLs and health records
- seed database with environments + URLs
- adjust health check loop to use URL structs
- display environment in the Angular dashboard

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848680ab49c8320b784d1f9e4b3a8b5