### PR TITLE
Refactor Angular dashboard structure

### DIFF
--- a/ui/src/app/api.service.ts
+++ b/ui/src/app/api.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface EnvironmentItem {
+  ID: number;
+  Name: string;
+}
+
+export interface URLItem {
+  ID: number;
+  Target: string;
+  Environment?: EnvironmentItem;
+}
+
+export interface RecordItem {
+  ID: number;
+  URLID: number;
+  StatusCode: number;
+  Timestamp: string;
+  URL?: URLItem;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ApiService {
+  constructor(private http: HttpClient) {}
+
+  getUrls(): Observable<URLItem[]> {
+    return this.http.get<URLItem[]>("/urls");
+  }
+
+  getRecords(): Observable<RecordItem[]> {
+    return this.http.get<RecordItem[]>("/records");
+  }
+}

--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -1,34 +1,6 @@
 <div class="dashboard">
   <h1>Health Check Dashboard</h1>
 
-  <section class="urls">
-    <h2>Monitored URLs</h2>
-    <ul class="url-list">
-      <li *ngFor="let u of urls">{{ u.Target }}</li>
-    </ul>
-  </section>
-
-  <section class="records">
-    <h2>Latest Checks</h2>
-    <table class="records-table">
-      <thead>
-        <tr>
-          <th>Environment</th>
-          <th>URL</th>
-          <th>Status</th>
-          <th>Timestamp</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr *ngFor="let r of records">
-          <td>{{ r.URL?.Environment?.Name }}</td>
-          <td>{{ r.URL?.Target }}</td>
-          <td [ngClass]="r.StatusCode < 400 ? 'status-up' : 'status-down'">
-            {{ r.StatusCode }}
-          </td>
-          <td>{{ r.Timestamp | date: "short" }}</td>
-        </tr>
-      </tbody>
-    </table>
-  </section>
+  <app-url-list></app-url-list>
+  <app-record-list></app-record-list>
 </div>

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -1,43 +1,14 @@
-import { Component, OnInit } from "@angular/core";
-import { HttpClient, HttpClientModule } from "@angular/common/http";
+import { Component } from "@angular/core";
+import { HttpClientModule } from "@angular/common/http";
 import { CommonModule } from "@angular/common";
-
-interface EnvironmentItem {
-  ID: number;
-  Name: string;
-}
-
-interface URLItem {
-  ID: number;
-  Target: string;
-  Environment?: EnvironmentItem;
-}
-
-interface RecordItem {
-  ID: number;
-  URLID: number;
-  StatusCode: number;
-  Timestamp: string;
-  URL?: URLItem;
-}
+import { UrlListComponent } from "./url-list.component";
+import { RecordListComponent } from "./record-list.component";
 
 @Component({
   selector: "app-root",
   standalone: true,
-  imports: [CommonModule, HttpClientModule],
+  imports: [CommonModule, HttpClientModule, UrlListComponent, RecordListComponent],
   templateUrl: "./app.component.html",
   styleUrls: ["./app.component.css"],
 })
-export class AppComponent implements OnInit {
-  urls: URLItem[] = [];
-  records: RecordItem[] = [];
-
-  constructor(private http: HttpClient) {}
-
-  ngOnInit() {
-    this.http.get<URLItem[]>("/urls").subscribe((d) => (this.urls = d));
-    this.http
-      .get<RecordItem[]>("/records")
-      .subscribe((d) => (this.records = d));
-  }
-}
+export class AppComponent {}

--- a/ui/src/app/record-list.component.css
+++ b/ui/src/app/record-list.component.css
@@ -1,0 +1,35 @@
+.records-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.records-table thead {
+  background: #343a40;
+  color: #fff;
+}
+
+.records-table th,
+.records-table td {
+  padding: 12px 16px;
+  text-align: left;
+}
+
+.records-table tbody tr:nth-child(even) {
+  background: #f5f5f5;
+}
+
+.records-table tbody tr:hover {
+  background: #e7f3ff;
+}
+
+.status-up {
+  color: #2e7d32;
+  font-weight: 600;
+}
+
+.status-down {
+  color: #c62828;
+  font-weight: 600;
+}

--- a/ui/src/app/record-list.component.html
+++ b/ui/src/app/record-list.component.html
@@ -1,0 +1,23 @@
+<section class="records">
+  <h2>Latest Checks</h2>
+  <table class="records-table">
+    <thead>
+      <tr>
+        <th>Environment</th>
+        <th>URL</th>
+        <th>Status</th>
+        <th>Timestamp</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let r of records">
+        <td>{{ r.URL?.Environment?.Name }}</td>
+        <td>{{ r.URL?.Target }}</td>
+        <td [ngClass]="r.StatusCode < 400 ? 'status-up' : 'status-down'">
+          {{ r.StatusCode }}
+        </td>
+        <td>{{ r.Timestamp | date: 'short' }}</td>
+      </tr>
+    </tbody>
+  </table>
+</section>

--- a/ui/src/app/record-list.component.ts
+++ b/ui/src/app/record-list.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ApiService, RecordItem } from './api.service';
+
+@Component({
+  selector: 'app-record-list',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './record-list.component.html',
+  styleUrls: ['./record-list.component.css'],
+})
+export class RecordListComponent implements OnInit {
+  records: RecordItem[] = [];
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit() {
+    this.api.getRecords().subscribe((d) => (this.records = d));
+  }
+}

--- a/ui/src/app/url-list.component.css
+++ b/ui/src/app/url-list.component.css
@@ -1,0 +1,9 @@
+.url-list {
+  list-style: none;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.url-list li {
+  padding: 4px 0;
+}

--- a/ui/src/app/url-list.component.html
+++ b/ui/src/app/url-list.component.html
@@ -1,0 +1,6 @@
+<section class="urls">
+  <h2>Monitored URLs</h2>
+  <ul class="url-list">
+    <li *ngFor="let u of urls">{{ u.Target }}</li>
+  </ul>
+</section>

--- a/ui/src/app/url-list.component.ts
+++ b/ui/src/app/url-list.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ApiService, URLItem } from './api.service';
+
+@Component({
+  selector: 'app-url-list',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './url-list.component.html',
+  styleUrls: ['./url-list.component.css'],
+})
+export class UrlListComponent implements OnInit {
+  urls: URLItem[] = [];
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit() {
+    this.api.getUrls().subscribe((d) => (this.urls = d));
+  }
+}


### PR DESCRIPTION
## Summary
- split the dashboard UI into `UrlListComponent` and `RecordListComponent`
- move HTTP requests into a shared `ApiService`
- simplify `AppComponent` template and imports

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68486c9510848320a5148390ace3463f