### PR TITLE
Fix Angular HttpClient provider

### DIFF
--- a/ui/src/app/app.config.ts
+++ b/ui/src/app/app.config.ts
@@ -1,9 +1,11 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    
+    provideHttpClient(),
+
   ]
 };


### PR DESCRIPTION
## Summary
- ensure HttpClient provider is included when bootstrapping the Angular app

## Testing
- `go test ./...` *(fails: no output due to environment limitations)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848734a427c83209c6fd0381edd0a87