### PR TITLE
Add uptime table UI component

### DIFF
--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -3,4 +3,5 @@
 
   <app-url-list></app-url-list>
   <app-record-list></app-record-list>
+  <app-uptime-table></app-uptime-table>
 </div>

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -3,11 +3,18 @@ import { HttpClientModule } from "@angular/common/http";
 import { CommonModule } from "@angular/common";
 import { UrlListComponent } from "./url-list/url-list.component";
 import { RecordListComponent } from "./record-list/record-list.component";
+import { UptimeTableComponent } from "./uptime-table/uptime-table.component";
 
 @Component({
   selector: "app-root",
   standalone: true,
-  imports: [CommonModule, HttpClientModule, UrlListComponent, RecordListComponent],
+  imports: [
+    CommonModule,
+    HttpClientModule,
+    UrlListComponent,
+    RecordListComponent,
+    UptimeTableComponent,
+  ],
   templateUrl: "./app.component.html",
   styleUrls: ["./app.component.css"],
 })

--- a/ui/src/app/uptime-table/uptime-table.component.css
+++ b/ui/src/app/uptime-table/uptime-table.component.css
@@ -1,0 +1,36 @@
+.uptime-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.uptime-table thead {
+  background: #343a40;
+  color: #fff;
+}
+
+.uptime-table th,
+.uptime-table td {
+  padding: 12px 16px;
+  text-align: left;
+}
+
+.uptime-table tbody tr:nth-child(even) {
+  background: #f5f5f5;
+}
+
+.uptime-table tbody tr:hover {
+  background: #e7f3ff;
+}
+
+.status-icon {
+  font-size: 1.2rem;
+}
+
+.graph-placeholder {
+  width: 100px;
+  height: 24px;
+  background: #e0e0e0;
+  border-radius: 4px;
+}

--- a/ui/src/app/uptime-table/uptime-table.component.html
+++ b/ui/src/app/uptime-table/uptime-table.component.html
@@ -1,0 +1,33 @@
+<section class="uptime">
+  <h2>Uptime Checks</h2>
+  <table class="uptime-table">
+    <thead>
+      <tr>
+        <th>Status</th>
+        <th>Environment</th>
+        <th>Tags</th>
+        <th>Location</th>
+        <th>Type</th>
+        <th>Uptime</th>
+        <th>Up Since</th>
+        <th>Response/Outages</th>
+        <th>Resp. Time</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let item of items">
+        <td class="status-icon">{{ item.up ? '✅' : '❌' }}</td>
+        <td>{{ item.environment }}</td>
+        <td>{{ item.tags.join(', ') }}</td>
+        <td>{{ item.location }}</td>
+        <td>{{ item.type }}</td>
+        <td>{{ item.uptime }}</td>
+        <td>{{ item.upSince }}</td>
+        <td><div class="graph-placeholder"></div></td>
+        <td>{{ item.responseTime }}</td>
+        <td><button>⋮</button></td>
+      </tr>
+    </tbody>
+  </table>
+</section>

--- a/ui/src/app/uptime-table/uptime-table.component.ts
+++ b/ui/src/app/uptime-table/uptime-table.component.ts
@@ -1,0 +1,45 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+interface UptimeItem {
+  up: boolean;
+  environment: string;
+  tags: string[];
+  location: string;
+  type: string;
+  uptime: string;
+  upSince: string;
+  responseTime: string;
+}
+
+@Component({
+  selector: 'app-uptime-table',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './uptime-table.component.html',
+  styleUrls: ['./uptime-table.component.css'],
+})
+export class UptimeTableComponent {
+  items: UptimeItem[] = [
+    {
+      up: true,
+      environment: 'Prod',
+      tags: ['api', 'critical'],
+      location: 'US-East',
+      type: 'https',
+      uptime: '99.9%',
+      upSince: '2025-06-01',
+      responseTime: '250ms',
+    },
+    {
+      up: false,
+      environment: 'Staging',
+      tags: ['internal'],
+      location: 'EU-West',
+      type: 'ping',
+      uptime: '97.5%',
+      upSince: '2025-05-27',
+      responseTime: '1.2s',
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- add Angular standalone component for uptime table design
- include new component in app

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684875cd8d948320baba0aadd5a93601