### PR TITLE
Add routing and simplify dashboard

### DIFF
--- a/ui/src/app/app.component.css
+++ b/ui/src/app/app.component.css
@@ -10,6 +10,13 @@ h1 {
   margin-bottom: 2rem;
 }
 
+.nav {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+
 
 .records-table {
   width: 100%;

--- a/ui/src/app/app.component.html
+++ b/ui/src/app/app.component.html
@@ -1,7 +1,10 @@
 <div class="dashboard">
   <h1>Health Check Dashboard</h1>
 
-  <app-url-list></app-url-list>
-  <app-record-list></app-record-list>
-  <app-uptime-table></app-uptime-table>
+  <nav class="nav">
+    <a routerLink="/">Uptime</a>
+    <a routerLink="/latest">Latest Checks</a>
+  </nav>
+
+  <router-outlet></router-outlet>
 </div>

--- a/ui/src/app/app.component.ts
+++ b/ui/src/app/app.component.ts
@@ -1,19 +1,13 @@
 import { Component } from "@angular/core";
-import { HttpClientModule } from "@angular/common/http";
 import { CommonModule } from "@angular/common";
-import { UrlListComponent } from "./url-list/url-list.component";
-import { RecordListComponent } from "./record-list/record-list.component";
-import { UptimeTableComponent } from "./uptime-table/uptime-table.component";
+import { RouterModule } from "@angular/router";
 
 @Component({
   selector: "app-root",
   standalone: true,
   imports: [
     CommonModule,
-    HttpClientModule,
-    UrlListComponent,
-    RecordListComponent,
-    UptimeTableComponent,
+    RouterModule,
   ],
   templateUrl: "./app.component.html",
   styleUrls: ["./app.component.css"],

--- a/ui/src/app/app.config.ts
+++ b/ui/src/app/app.config.ts
@@ -1,11 +1,20 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideHttpClient } from '@angular/common/http';
+import { provideRouter, Routes } from '@angular/router';
+import { UptimeTableComponent } from './uptime-table/uptime-table.component';
+import { RecordListComponent } from './record-list/record-list.component';
+
+const routes: Routes = [
+  { path: '', component: UptimeTableComponent },
+  { path: 'latest', component: RecordListComponent },
+];
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideHttpClient(),
+    provideRouter(routes),
 
   ]
 };


### PR DESCRIPTION
## Summary
- route `RecordListComponent` to `/latest` with Angular Router
- remove URL list from dashboard and display only uptime table on home page
- add simple navigation links

## Testing
- `npm run build`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_684892ca38a88320b36b98f20e04691e