### PR TITLE
Expand dashboard width

### DIFF
--- a/ui/src/app/app.component.css
+++ b/ui/src/app/app.component.css
@@ -29,7 +29,8 @@
 }
 
 .dashboard {
-  max-width: 960px;
+  width: 95%;
+  max-width: none;
   margin: 2rem auto;
   padding: 0 20px;
   font-family: Arial, Helvetica, sans-serif;


### PR DESCRIPTION
## Summary
- make the dashboard container fill most of the page

## Testing
- `go build ./...`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684896b99cb08320aa0058c995d23dff