### PR TITLE
Implement backend-driven uptime view

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -21,6 +22,7 @@ func main() {
 
 	app.Get("/urls", getURLs)
 	app.Get("/records", getRecords)
+	app.Get("/uptimes", getUptimes)
 
 	app.Static("/", "./ui/dist/ui/browser")
 	app.Use(func(c *fiber.Ctx) error {
@@ -73,4 +75,79 @@ func getRecords(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).SendString(result.Error.Error())
 	}
 	return c.JSON(records)
+}
+
+func getUptimes(c *fiber.Ctx) error {
+	var urls []models.URL
+	result := db.DB.Preload("Environment").Preload("Tags").Preload("Location").Preload("CheckType").Find(&urls)
+	if result.Error != nil {
+		return c.Status(fiber.StatusInternalServerError).SendString(result.Error.Error())
+	}
+
+	type UptimeItem struct {
+		Up           bool     `json:"up"`
+		Environment  string   `json:"environment"`
+		Tags         []string `json:"tags"`
+		Location     string   `json:"location"`
+		Type         string   `json:"type"`
+		Uptime       string   `json:"uptime"`
+		UpSince      string   `json:"upSince"`
+		ResponseTime string   `json:"responseTime"`
+	}
+
+	var items []UptimeItem
+
+	for _, u := range urls {
+		var records []models.HealthCheckRecord
+		r := db.DB.Where("url_id = ?", u.ID).Order("timestamp desc").Limit(100).Find(&records)
+		if r.Error != nil || len(records) == 0 {
+			continue
+		}
+
+		var successCount int
+		var totalResp int64
+		upSince := records[0].Timestamp
+
+		for i, rec := range records {
+			if rec.StatusCode >= 200 && rec.StatusCode < 300 {
+				successCount++
+				if i == 0 {
+					upSince = rec.Timestamp
+				}
+			} else if i == 0 {
+				upSince = time.Time{}
+			} else if upSince.Equal(records[i-1].Timestamp) {
+				upSince = time.Time{}
+			}
+			totalResp += rec.ResponseTime
+		}
+
+		uptimePercent := float64(successCount) / float64(len(records)) * 100
+		last := records[0]
+		up := last.StatusCode >= 200 && last.StatusCode < 300
+		avgResp := totalResp / int64(len(records))
+
+		tagNames := make([]string, len(u.Tags))
+		for i, t := range u.Tags {
+			tagNames[i] = t.Name
+		}
+
+		upSinceStr := ""
+		if !upSince.IsZero() {
+			upSinceStr = upSince.Format("2006-01-02 15:04")
+		}
+
+		items = append(items, UptimeItem{
+			Up:           up,
+			Environment:  u.Environment.Name,
+			Tags:         tagNames,
+			Location:     u.Location.Name,
+			Type:         u.CheckType.Name,
+			Uptime:       fmt.Sprintf("%.1f%%", uptimePercent),
+			UpSince:      upSinceStr,
+			ResponseTime: fmt.Sprintf("%dms", avgResp),
+		})
+	}
+
+	return c.JSON(items)
 }

--- a/ui/src/app/api.service.ts
+++ b/ui/src/app/api.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Injectable } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable } from "rxjs";
 
 export interface EnvironmentItem {
   ID: number;
@@ -21,7 +21,18 @@ export interface RecordItem {
   URL?: URLItem;
 }
 
-@Injectable({ providedIn: 'root' })
+export interface UptimeItem {
+  up: boolean;
+  environment: string;
+  tags: string[];
+  location: string;
+  type: string;
+  uptime: string;
+  upSince: string;
+  responseTime: string;
+}
+
+@Injectable({ providedIn: "root" })
 export class ApiService {
   constructor(private http: HttpClient) {}
 
@@ -31,5 +42,9 @@ export class ApiService {
 
   getRecords(): Observable<RecordItem[]> {
     return this.http.get<RecordItem[]>("/records");
+  }
+
+  getUptimes(): Observable<UptimeItem[]> {
+    return this.http.get<UptimeItem[]>("/uptimes");
   }
 }

--- a/ui/src/app/uptime-table/uptime-table.component.ts
+++ b/ui/src/app/uptime-table/uptime-table.component.ts
@@ -1,45 +1,20 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
-
-interface UptimeItem {
-  up: boolean;
-  environment: string;
-  tags: string[];
-  location: string;
-  type: string;
-  uptime: string;
-  upSince: string;
-  responseTime: string;
-}
+import { Component, OnInit } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { ApiService, UptimeItem } from "../api.service";
 
 @Component({
-  selector: 'app-uptime-table',
+  selector: "app-uptime-table",
   standalone: true,
   imports: [CommonModule],
-  templateUrl: './uptime-table.component.html',
-  styleUrls: ['./uptime-table.component.css'],
+  templateUrl: "./uptime-table.component.html",
+  styleUrls: ["./uptime-table.component.css"],
 })
-export class UptimeTableComponent {
-  items: UptimeItem[] = [
-    {
-      up: true,
-      environment: 'Prod',
-      tags: ['api', 'critical'],
-      location: 'US-East',
-      type: 'https',
-      uptime: '99.9%',
-      upSince: '2025-06-01',
-      responseTime: '250ms',
-    },
-    {
-      up: false,
-      environment: 'Staging',
-      tags: ['internal'],
-      location: 'EU-West',
-      type: 'ping',
-      uptime: '97.5%',
-      upSince: '2025-05-27',
-      responseTime: '1.2s',
-    },
-  ];
+export class UptimeTableComponent implements OnInit {
+  items: UptimeItem[] = [];
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit() {
+    this.api.getUptimes().subscribe((d) => (this.items = d));
+  }
 }


### PR DESCRIPTION
## Summary
- add `/uptimes` API endpoint in Go server
- fetch uptime data in Angular service and component
- display uptime table with backend data

## Testing
- `gofmt -w main.go`
- `npx prettier -w ui/src/app/api.service.ts ui/src/app/uptime-table/uptime-table.component.ts`
- `go vet ./...` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6849ed044f008320a8d0f5e488b7f41a